### PR TITLE
Smaller docker image and multiarch build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ COPY . .
 # Build the SvelteKit app
 RUN npm run build
 
+EXPOSE 3000
+
 # Use pm2 and server script as the entry point
 CMD ["pm2-runtime", "server/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node.js 16 image from Docker Hub
-FROM node:16
+FROM node:16-alpine
 
 # Set the working directory
 WORKDIR /usr/src/app/msp

--- a/docker-multiarch-build.sh
+++ b/docker-multiarch-build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# set up docker platform emulation (only need to do this once)
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+# build amd64 and arm64 images and push to docker hub
+docker buildx build --platform linux/amd64,linux/arm64/v8 --tag thebells1111/federated-msp:latest --push .


### PR DESCRIPTION
Switched out the full fat Docker `node:16` base image with the significantly smaller `node:16-alpine` image. Since Docker builds images by layering files on top of the previous layer, starting from a smaller base layer results in a smaller final image.

Also, added a script to build `amd64` and `arm64` images since Umbrel and Start9 can run on both architectures.